### PR TITLE
Fixes #24 - Invalid spring profile when using default bootRunLocal

### DIFF
--- a/gradle-localstack-plugin/src/main/java/com/nike/pdm/localstack/boot/SpringBootModule.java
+++ b/gradle-localstack-plugin/src/main/java/com/nike/pdm/localstack/boot/SpringBootModule.java
@@ -136,7 +136,7 @@ public class SpringBootModule {
                 jvmArgs.add(String.format(BOOT_PROFILES_ARG_FORMAT, String.join(",", ext.getSpringboot().getProfiles())));
             }
         } else {
-            jvmArgs.add(String.format(BOOT_PROFILES_ARG_FORMAT, SpringBootExtension.DEFAULT_PROFILES));
+            jvmArgs.add(String.format(BOOT_PROFILES_ARG_FORMAT, String.join(",", SpringBootExtension.DEFAULT_PROFILES)));
         }
     }
 }


### PR DESCRIPTION
Fixes the issue where if you did not specify a spring boot profile when using bootRunLocal it would default to the string representation of the list instead of a comma-delimited string list.